### PR TITLE
Add FCFS, SJF, SRTF, Multi-level Queue and MLFQ scheduling algorithms

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,10 +19,12 @@ int main() {
         p.remaining_time = p.burst_time;
         plist.push_back(p);
     }
-    std::cout << "Select scheduling algorithm (0: Round Robin, 1: Priority Preemptive): ";
+    std::cout << "Select scheduling algorithm:\n";
+    std::cout << "0: Round Robin\n1: FCFS\n2: SJF\n3: SRTF\n4: Multi-level Queue\n5: Multi-level Feedback\n6: Priority Preemptive\n";
+    std::cout << "Enter choice: ";
     std::cin >> type;
-    if (type == 0) {
-        std::cout << "Enter time quantum: ";
+    if (type == 0 || type == 4 || type == 5) {
+        std::cout << "Enter time quantum (suggest 1): ";
         std::cin >> quantum;
     }
     Scheduler scheduler(static_cast<SchedulingType>(type), quantum);

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -21,10 +21,15 @@ void Scheduler::run() {
         p.is_completed = false;
         pthread_create(&p.thread, nullptr, Scheduler::processThreadFunc, &p);
     }
-    if (type == ROUND_ROBIN) {
-        roundRobin();
-    } else {
-        priorityPreemptive();
+    switch (type) {
+        case ROUND_ROBIN: roundRobin(); break;
+        case FCFS: fcfs(); break;
+        case SJF: sjf(); break;
+        case SRTF: srtf(); break;
+        case MULTI_LEVEL_QUEUE: multiLevelQueue(); break;
+        case MULTI_LEVEL_FEEDBACK: multiLevelFeedback(); break;
+        case PRIORITY_PREEMPTIVE: priorityPreemptive(); break;
+        default: roundRobin(); break;
     }
     // Wait for all threads to finish
     for (auto& p : processes) {
@@ -155,5 +160,176 @@ void Scheduler::priorityPreemptive() {
             pthread_mutex_unlock(&p->proc_mutex);
             completed++;
         }
+    }
+}
+
+// First-Come First-Serve (non-preemptive)
+void Scheduler::fcfs() {
+    int time = 0;
+    // sort by arrival time
+    std::vector<Process*> order;
+    for (auto &p : processes) order.push_back(&p);
+    std::sort(order.begin(), order.end(), [](Process* a, Process* b){
+        return a->arrival_time < b->arrival_time;
+    });
+    for (auto p : order) {
+        if (time < p->arrival_time) time = p->arrival_time;
+        gantt_chart.push_back("P" + std::to_string(p->pid));
+        // run until completion
+        while (p->remaining_time > 0) {
+            pthread_mutex_lock(&p->proc_mutex);
+            p->is_running = true;
+            pthread_cond_signal(&p->proc_cond);
+            pthread_mutex_unlock(&p->proc_mutex);
+            usleep(100000);
+            p->remaining_time--;
+            time++;
+        }
+        p->finish_time = time;
+        p->turnaround_time = p->finish_time - p->arrival_time;
+        p->wait_time = p->turnaround_time - p->burst_time;
+        p->is_completed = true;
+    }
+}
+
+// Shortest Job First (non-preemptive)
+void Scheduler::sjf() {
+    int time = 0, completed = 0;
+    size_t n = processes.size();
+    while (completed < n) {
+        // find ready processes
+        std::vector<Process*> ready;
+        for (auto &p : processes) if (p.arrival_time <= time && p.remaining_time > 0) ready.push_back(&p);
+        if (ready.empty()) { time++; continue; }
+        std::sort(ready.begin(), ready.end(), [](Process* a, Process* b){ return a->burst_time < b->burst_time; });
+        Process* p = ready.front();
+        gantt_chart.push_back("P" + std::to_string(p->pid));
+        // run to completion
+        while (p->remaining_time > 0) {
+            pthread_mutex_lock(&p->proc_mutex);
+            p->is_running = true;
+            pthread_cond_signal(&p->proc_cond);
+            pthread_mutex_unlock(&p->proc_mutex);
+            usleep(100000);
+            p->remaining_time--;
+            time++;
+        }
+        p->finish_time = time;
+        p->turnaround_time = p->finish_time - p->arrival_time;
+        p->wait_time = p->turnaround_time - p->burst_time;
+        p->is_completed = true;
+        completed++;
+    }
+}
+
+// Shortest Remaining Time First (preemptive SJF)
+void Scheduler::srtf() {
+    int time = 0, completed = 0;
+    size_t n = processes.size();
+    while (completed < n) {
+        std::vector<Process*> ready;
+        for (auto &p : processes) if (p.arrival_time <= time && p.remaining_time > 0) ready.push_back(&p);
+        if (ready.empty()) { time++; continue; }
+        std::sort(ready.begin(), ready.end(), [](Process* a, Process* b){ return a->remaining_time < b->remaining_time; });
+        Process* p = ready.front();
+        gantt_chart.push_back("P" + std::to_string(p->pid));
+        pthread_mutex_lock(&p->proc_mutex);
+        p->is_running = true;
+        pthread_cond_signal(&p->proc_cond);
+        pthread_mutex_unlock(&p->proc_mutex);
+        usleep(100000);
+        p->remaining_time--;
+        time++;
+        if (p->remaining_time == 0) {
+            p->finish_time = time;
+            p->turnaround_time = p->finish_time - p->arrival_time;
+            p->wait_time = p->turnaround_time - p->burst_time;
+            p->is_completed = true;
+            completed++;
+        }
+    }
+}
+
+// Multi-level queue: queue 0 is RR with quantum, queue 1 is FCFS
+void Scheduler::multiLevelQueue() {
+    int time = 0, completed = 0;
+    size_t n = processes.size();
+    std::vector<Process*> q0, q1;
+    while (completed < n) {
+        for (auto &p : processes) {
+            if (p.arrival_time <= time && p.remaining_time > 0) {
+                // simple classification: priority < 5 => foreground
+                if (p.priority < 5) {
+                    if (std::find(q0.begin(), q0.end(), &p) == q0.end()) q0.push_back(&p);
+                } else {
+                    if (std::find(q1.begin(), q1.end(), &p) == q1.end()) q1.push_back(&p);
+                }
+            }
+        }
+        if (!q0.empty()) {
+            Process* p = q0.front(); q0.erase(q0.begin());
+            int exec = std::min(quantum, p->remaining_time);
+            for (int i = 0; i < exec; ++i) {
+                gantt_chart.push_back("P" + std::to_string(p->pid));
+                pthread_mutex_lock(&p->proc_mutex);
+                p->is_running = true;
+                pthread_cond_signal(&p->proc_cond);
+                pthread_mutex_unlock(&p->proc_mutex);
+                usleep(100000);
+                p->remaining_time--; time++;
+            }
+            if (p->remaining_time > 0) q0.push_back(p); else { p->is_completed = true; completed++; p->finish_time = time; p->turnaround_time = p->finish_time - p->arrival_time; p->wait_time = p->turnaround_time - p->burst_time; }
+        } else if (!q1.empty()) {
+            Process* p = q1.front(); q1.erase(q1.begin());
+            // run to completion FCFS
+            while (p->remaining_time > 0) {
+                gantt_chart.push_back("P" + std::to_string(p->pid));
+                pthread_mutex_lock(&p->proc_mutex);
+                p->is_running = true;
+                pthread_cond_signal(&p->proc_cond);
+                pthread_mutex_unlock(&p->proc_mutex);
+                usleep(100000);
+                p->remaining_time--; time++;
+            }
+            p->is_completed = true; completed++; p->finish_time = time; p->turnaround_time = p->finish_time - p->arrival_time; p->wait_time = p->turnaround_time - p->burst_time;
+        } else { time++; }
+    }
+}
+
+// Multi-level feedback queue: 3 levels with increasing quantum
+void Scheduler::multiLevelFeedback() {
+    int time = 0, completed = 0;
+    size_t n = processes.size();
+    std::vector<Process*> levels[3];
+    int quantums[3] = {quantum, quantum*2, quantum*4};
+    while (completed < n) {
+        for (auto &p : processes) {
+            if (p.arrival_time <= time && p.remaining_time > 0) {
+                bool found=false;
+                for (int l=0;l<3;++l) if (std::find(levels[l].begin(), levels[l].end(), &p) != levels[l].end()) found=true;
+                if (!found) levels[0].push_back(&p);
+            }
+        }
+        bool did=false;
+        for (int lvl=0; lvl<3 && !did; ++lvl) {
+            if (levels[lvl].empty()) continue;
+            Process* p = levels[lvl].front(); levels[lvl].erase(levels[lvl].begin());
+            int exec = std::min(quantums[lvl], p->remaining_time);
+            for (int i=0;i<exec;++i) {
+                gantt_chart.push_back("P" + std::to_string(p->pid));
+                pthread_mutex_lock(&p->proc_mutex);
+                p->is_running = true;
+                pthread_cond_signal(&p->proc_cond);
+                pthread_mutex_unlock(&p->proc_mutex);
+                usleep(100000);
+                p->remaining_time--; time++;
+            }
+            if (p->remaining_time > 0) {
+                if (lvl < 2) levels[lvl+1].push_back(p);
+                else levels[lvl].push_back(p);
+            } else { p->is_completed=true; completed++; p->finish_time=time; p->turnaround_time=p->finish_time-p->arrival_time; p->wait_time=p->turnaround_time-p->burst_time; }
+            did=true;
+        }
+        if (!did) time++;
     }
 }

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -25,6 +25,11 @@ struct Process {
 
 enum SchedulingType {
     ROUND_ROBIN,
+    FCFS,
+    SJF,
+    SRTF,
+    MULTI_LEVEL_QUEUE,
+    MULTI_LEVEL_FEEDBACK,
     PRIORITY_PREEMPTIVE
 };
 
@@ -42,6 +47,11 @@ private:
     pthread_mutex_t mutex;
     std::vector<std::string> gantt_chart;
     void roundRobin();
+    void fcfs();
+    void sjf();
+    void srtf();
+    void multiLevelQueue();
+    void multiLevelFeedback();
     void priorityPreemptive();
     static void* processThreadFunc(void* arg);
 };


### PR DESCRIPTION
### **PR Title**

Add FCFS, SJF, SRTF, Multi-level Queue, and MLFQ scheduling algorithms

### **Description**

Implemented five new CPU scheduling algorithms and updated the interactive simulator menu:

* **FCFS** – First-Come, First-Serve (non-preemptive)
* **SJF** – Shortest Job First (non-preemptive)
* **SRTF** – Shortest Remaining Time First (preemptive)
* **Multi-level Queue** – two-level (foreground RR, background FCFS)
* **MLFQ** – three-level feedback queues with increasing quantums

Each algorithm reuses the existing thread-based process model and simulated time (`1 unit ≈ 0.1s`).

### **Files Changed**

* `scheduler.h` – added new enum values & declarations
* `scheduler.cpp` – implemented algorithms and dispatch logic
* `main.cpp` – extended menu and quantum input handling

### **Build & Run**

```bash
g++ -std=c++11 -pthread src/main.cpp src/scheduler.cpp -o scheduler.exe
./scheduler.exe
```

### **Notes**

* Multi-level queue uses `priority < 5` for foreground classification
* MLFQ uses progressive quantums: `q`, `2q`, `4q`
* Intended for teaching/visualization

### **Reviewer Checklist**

* [x] All algorithms appear in menu
* [x] Builds and runs successfully
* [x] Wait/turnaround stats display correctly

